### PR TITLE
Expand wordpress utility bridge

### DIFF
--- a/client/src/styles/wordpress.css
+++ b/client/src/styles/wordpress.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 
+.has-extra-small-font-size {
+  @apply text-xs;
+}
+
 .has-x-large-font-size {
   @apply text-4xl;
 }
@@ -8,12 +12,26 @@
   @apply text-2xl;
 }
 
+.has-larger-font-size {
+  @apply text-3xl;
+}
+
 .has-medium-font-size {
+  @apply text-base;
+}
+
+.has-normal-font-size,
+.has-regular-font-size {
   @apply text-base;
 }
 
 .has-small-font-size {
   @apply text-sm;
+}
+
+.has-huge-font-size,
+.has-xx-large-font-size {
+  @apply text-6xl;
 }
 
 .has-text-align-center {
@@ -28,8 +46,20 @@
   @apply text-right;
 }
 
+.has-text-align-justify {
+  @apply text-justify;
+}
+
 .aligncenter {
   @apply mx-auto;
+}
+
+.alignleft {
+  @apply float-left mr-6;
+}
+
+.alignright {
+  @apply float-right ml-6;
 }
 
 .alignwide {
@@ -38,4 +68,20 @@
 
 .alignfull {
   @apply w-screen;
+}
+
+.wp-block-image img {
+  @apply max-w-full h-auto;
+}
+
+.wp-block-quote {
+  @apply border-l-4 border-gray-300 pl-4 italic;
+}
+
+.wp-block-separator {
+  @apply border-t border-gray-300 my-8;
+}
+
+.wp-block-button__link {
+  @apply inline-block px-4 py-2 rounded;
 }


### PR DESCRIPTION
## Summary
- extend `wordpress.css` to map more WordPress classes to Tailwind utility classes

## Testing
- `npm run lint` *(fails: 'process' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685f5ec39c008328bc8bdc49001244b3